### PR TITLE
Add fn to remove JCE restrictions when running on Oracle's JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ In a Rails app you will find those values in
   (create-session-decryptor secret-key-base custom-signature-salt custom-encryption-salt))
 ```
 
+
+### Not working?
+
+Despite correct settings decryption might not work.
+Certain JVMs by default restrict longer encryption keys, to disable that behaviour call:
+
+```clojure
+
+(require '[rails-session-clojure.core :as rsc])
+(rsc/disable-crypto-restriction!)
+
+```
+
+when your application starts.
+
 ## Documentation
 
 * [API Docs](http://mkwiatkowski.github.io/rails-session-clojure/index.html)

--- a/src/rails_session_clojure/core.clj
+++ b/src/rails_session_clojure/core.clj
@@ -10,6 +10,16 @@
    [crypto.random :as random]
    [pandect.core :as pandect]))
 
+(defn disable-crypto-restriction!
+  "Disable JCE restrictions to enable strong encryption. Call this function
+  if crypto doesn't work despite correct settings.
+  Note: applies only to Oracle's JVM."
+  []
+  (let [field (.getDeclaredField (Class/forName "javax.crypto.JceSecurity") "isRestricted")]
+    (doto field
+      (.setAccessible true)
+      (.set nil false))))
+
 ;; Based on http://adambard.com/blog/3-wrong-ways-to-store-a-password/
 (defn pbkdf2
   "Returns bytes array of the specified length derived from applying PBKDF2


### PR DESCRIPTION
Hi! 

This might trip-up some folks - some JVM versions disable certain key lengths [due to JCE restrictions](http://stackoverflow.com/questions/14552303/opensslcipherciphererror-with-rails4-on-jruby).

Since it might not be legal to by default disable the restriction, I've simply added a fn that needs to be called once (ideally when application starts).

Thanks!